### PR TITLE
Try again to fix mkl paths

### DIFF
--- a/find_compilers_packages.py
+++ b/find_compilers_packages.py
@@ -178,7 +178,7 @@ def main(args):
     }
 
     prefix_configure = {
-        "intel-mkl":  "intel-ct/{version}/mkl"
+        "intel-mkl": "intel/compilers_and_libraries_{version}/linux/mkl"
     }
 
     for modstring, specstring in external_packages.items():

--- a/packages.yaml
+++ b/packages.yaml
@@ -359,59 +359,59 @@ packages:
   intel-mkl:
     externals:
     - spec: intel-mkl@2019.3.199
-      prefix: /apps/intel-ct/2019.3.199/mkl
+      prefix: /apps/intel/compilers_and_libraries_2019.3.199/linux/mkl
       modules:
       - intel-mkl/2019.3.199
     - spec: intel-mkl@2019.4.243
-      prefix: /apps/intel-ct/2019.4.243/mkl
+      prefix: /apps/intel/compilers_and_libraries_2019.4.243/linux/mkl
       modules:
       - intel-mkl/2019.4.243
     - spec: intel-mkl@2019.5.281
-      prefix: /apps/intel-ct/2019.5.281/mkl
+      prefix: /apps/intel/compilers_and_libraries_2019.5.281/linux/mkl
       modules:
       - intel-mkl/2019.5.281
     - spec: intel-mkl@2020.0.166
-      prefix: /apps/intel-ct/2020.0.166/mkl
+      prefix: /apps/intel/compilers_and_libraries_2020.0.166/linux/mkl
       modules:
       - intel-mkl/2020.0.166
     - spec: intel-mkl@2020.1.217
-      prefix: /apps/intel-ct/2020.1.217/mkl
+      prefix: /apps/intel/compilers_and_libraries_2020.1.217/linux/mkl
       modules:
       - intel-mkl/2020.1.217
     - spec: intel-mkl@2020.2.254
-      prefix: /apps/intel-ct/2020.2.254/mkl
+      prefix: /apps/intel/compilers_and_libraries_2020.2.254/linux/mkl
       modules:
       - intel-mkl/2020.2.254
     - spec: intel-mkl@2020.3.304
-      prefix: /apps/intel-ct/2020.3.304/mkl
+      prefix: /apps/intel/compilers_and_libraries_2020.3.304/linux/mkl
       modules:
       - intel-mkl/2020.3.304
     - spec: intel-mkl@2021.1.1
-      prefix: /apps/intel-ct/2021.1.1/mkl
+      prefix: /apps/intel/compilers_and_libraries_2021.1.1/linux/mkl
       modules:
       - intel-mkl/2021.1.1
     - spec: intel-mkl@2021.2.0
-      prefix: /apps/intel-ct/2021.2.0/mkl
+      prefix: /apps/intel/compilers_and_libraries_2021.2.0/linux/mkl
       modules:
       - intel-mkl/2021.2.0
     - spec: intel-mkl@2021.3.0
-      prefix: /apps/intel-ct/2021.3.0/mkl
+      prefix: /apps/intel/compilers_and_libraries_2021.3.0/linux/mkl
       modules:
       - intel-mkl/2021.3.0
     - spec: intel-mkl@2021.4.0
-      prefix: /apps/intel-ct/2021.4.0/mkl
+      prefix: /apps/intel/compilers_and_libraries_2021.4.0/linux/mkl
       modules:
       - intel-mkl/2021.4.0
     - spec: intel-mkl@2022.0.2
-      prefix: /apps/intel-ct/2022.0.2/mkl
+      prefix: /apps/intel/compilers_and_libraries_2022.0.2/linux/mkl
       modules:
       - intel-mkl/2022.0.2
     - spec: intel-mkl@2022.1.0
-      prefix: /apps/intel-ct/2022.1.0/mkl
+      prefix: /apps/intel/compilers_and_libraries_2022.1.0/linux/mkl
       modules:
       - intel-mkl/2022.1.0
     - spec: intel-mkl@2022.2.0
-      prefix: /apps/intel-ct/2022.2.0/mkl
+      prefix: /apps/intel/compilers_and_libraries_2022.2.0/linux/mkl
       modules:
       - intel-mkl/2022.2.0
     buildable: false


### PR DESCRIPTION
Previous fix (#2) didn't work as the code for find `mkl` has a very strict idea of where the library should be.

This fix tries to use a more standard location path.

Closes #1
