### PR TITLE
Added openmpi@5.0.8

### DIFF
--- a/common/gadi/packages.yaml
+++ b/common/gadi/packages.yaml
@@ -116,6 +116,13 @@ packages:
         environment:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/5.0.5/include/GNU
+    - spec: openmpi@5.0.8 %gcc
+      prefix: /apps/openmpi/5.0.8
+      modules: [openmpi/5.0.8]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/5.0.8/include/GNU
     - spec: openmpi@4.0.1 %intel
       prefix: /apps/openmpi/4.0.1
       modules: [openmpi/4.0.1]
@@ -221,6 +228,13 @@ packages:
         environment:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/5.0.5/include/Intel
+    - spec: openmpi@5.0.8 %intel
+      prefix: /apps/openmpi/5.0.8
+      modules: [openmpi/5.0.8]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/5.0.8/include/Intel
     - spec: openmpi@4.0.1 %oneapi
       prefix: /apps/openmpi/4.0.1
       modules: [openmpi/4.0.1]
@@ -326,6 +340,13 @@ packages:
         environment:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/5.0.5/include/Intel
+    - spec: openmpi@5.0.8 %oneapi
+      prefix: /apps/openmpi/5.0.8
+      modules: [openmpi/5.0.8]
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/5.0.8/include/Intel
     buildable: false
   perl:
     externals:


### PR DESCRIPTION
Tested with the following, and a bonus `time` for the last (oneapi) install 

```sh
[~ @gadi-login-07]$ which spack
/g/data/tm70/ms2335/spack/0.22/spack/bin/spack
[~ @gadi-login-07]$ spack install openmpi@5.0.8 %intel target=x86_64
==> openmpi@5.0.8 : has external module in ['openmpi/5.0.8']
[+] /apps/openmpi/5.0.8 (external openmpi-5.0.8-zzukdsffygtrbjuf45zi7cd4zeo4wjmd)
[~ @gadi-login-07]$ spack install openmpi@5.0.8 %gcc target=x86_64
==> openmpi@5.0.8 : has external module in ['openmpi/5.0.8']
[+] /apps/openmpi/5.0.8 (external openmpi-5.0.8-sx2tsdspbblaw5uy4qafafbot5aylzvc)
[~ @gadi-login-07]$ time spack install openmpi@5.0.8 %oneapi target=x86_64
==> openmpi@5.0.8 : has external module in ['openmpi/5.0.8']
[+] /apps/openmpi/5.0.8 (external openmpi-5.0.8-aeax2vxflua2vbiapxw2atc4p2iblcaq)

real    1m55.332s
user    1m16.995s
sys     0m29.308s
[~ @gadi-login-07]$ 

```