### PR TITLE
v1.0: Update builtin spack-packages commit

### DIFF
--- a/v1.0/all/repos.yaml
+++ b/v1.0/all/repos.yaml
@@ -3,5 +3,5 @@ repos::
   access_spack_packages: $spack/../spack-packages/spack_repo/access/nri
   builtin:
     git: https://github.com/spack/spack-packages.git
-    # Fix external Intel classic compiler (#981)
-    commit: 1788fb4b16f4e1478e149de56ba3040d8d5f51d6
+    # FMS: add 2025 releases and limit io deprecation variant (#790)
+    commit: 60517d15b003ddb01214ae1f949fc1180cb68049


### PR DESCRIPTION
I'm testing some of the features of Spack v1.0 in the [MOM6 build-CI](https://github.com/ACCESS-NRI/MOM6/pull/24). However, I require FMS>=2025.02 which is not available in the version of builtin spack-packages we are currently using. This PR updates the builtin spack-packages to the commit that adds the versions I need.