### PR TITLE
`ACCESS-NRI/spack-packages` as git-based packages repo

### DIFF
--- a/common-api-v2/repos.yaml
+++ b/common-api-v2/repos.yaml
@@ -1,6 +1,8 @@
 # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
 repos::
-  access_spack_packages: $spack/../spack-packages/spack_repo/access/nri
+  access_spack_packages:
+    git: https://github.com/ACCESS-NRI/access-spack-packages.git
+    branch: api-v2
   builtin:
     git: https://github.com/spack/spack-packages.git
     # FMS: add 2025 releases and limit io deprecation variant (#790)


### PR DESCRIPTION
References #81 

## Background

Rather than having our `spack-packages` repository as a path-based repo in our configuration, we should make use of the new `spack repo` commands and update it to a git-based repository. 

This will make existing `build-ci` and `build-cd` repositories have less custom logic, as we can use `spack` commands to interrogate packages repositories. 

## The PR

* Change `ACCESS-NRI/spack-packages` to a git-based packages repository in the `common-api-v2` `repos.yaml` (affecting all linked files)

## Testing

See https://github.com/ACCESS-NRI/spack-packages/pull/339