### PR TITLE
Support Spack v1.1

### DIFF
--- a/common-api-v2/concretizer.yaml
+++ b/common-api-v2/concretizer.yaml
@@ -1,0 +1,5 @@
+concretizer:
+  targets:
+    # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
+    granularity:: generic
+    compiler_mixing: false

--- a/common-api-v2/repos.yaml
+++ b/common-api-v2/repos.yaml
@@ -6,4 +6,6 @@ repos::
   builtin:
     git: https://github.com/spack/spack-packages.git
     # fckit: add depends_on("c") (#2379)
-    commit: 459c715dccfcedadeaab6f364ccee62c8a3e0eaa
+    # commit: 459c715dccfcedadeaab6f364ccee62c8a3e0eaa
+    # Commit before the one that breaks the intel classic compiler
+    commit: 8ed34337e15d759890b68682d704aa55dd243537

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -9,3 +9,7 @@ config:
   # Increasing from 1 minute to 10 minutes to allow for concurrent builds
   # to wait longer for .spack-db lock rather than exiting early.
   db_lock_timeout: 600
+  # Set deprecated to true, to avoid:
+  # Error: Version requirement 3.31.6 on cmake for cmake cannot match any
+  #        known version from package.py or externals
+  deprecated: true

--- a/v1.1/ci/concretizer.yaml
+++ b/v1.1/ci/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/concretizer.yaml

--- a/v1.1/ci/config.yaml
+++ b/v1.1/ci/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v1.1/ci/modules.yaml
+++ b/v1.1/ci/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v1.1/ci/packages.yaml
+++ b/v1.1/ci/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v1.1/ci/repos.yaml
+++ b/v1.1/ci/repos.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/repos.yaml

--- a/v1.1/gadi/concretizer.yaml
+++ b/v1.1/gadi/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/concretizer.yaml

--- a/v1.1/gadi/config.yaml
+++ b/v1.1/gadi/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v1.1/gadi/modules.yaml
+++ b/v1.1/gadi/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v1.1/gadi/packages.yaml
+++ b/v1.1/gadi/packages.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/gadi/packages.yaml

--- a/v1.1/gadi/repos.yaml
+++ b/v1.1/gadi/repos.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/repos.yaml


### PR DESCRIPTION
* common-api-v2/concretizer.yaml: set concretizer:compiler_mixing:false
* common/config.yaml: set deprecated:true to ensure Gadi's CMake version is accepted
* repos.yaml: use commit before the one that breaks the intel classic compiler