### PR TITLE
`build-ci` Support for `spack v1.1`

### DIFF
--- a/v1.1/ci-runner/concretizer.yaml
+++ b/v1.1/ci-runner/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/concretizer.yaml

--- a/v1.1/ci-runner/config.yaml
+++ b/v1.1/ci-runner/config.yaml
@@ -1,0 +1,1 @@
+../../common/config.yaml

--- a/v1.1/ci-runner/modules.yaml
+++ b/v1.1/ci-runner/modules.yaml
@@ -1,0 +1,1 @@
+../../common/modules.yaml

--- a/v1.1/ci-runner/packages.yaml
+++ b/v1.1/ci-runner/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v1.1/ci-runner/repos.yaml
+++ b/v1.1/ci-runner/repos.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/repos.yaml

--- a/v1.1/ci-runner/upstreams.yaml
+++ b/v1.1/ci-runner/upstreams.yaml
@@ -1,0 +1,1 @@
+../../common/ci-runner/upstreams.yaml

--- a/v1.1/ci-upstream/concretizer.yaml
+++ b/v1.1/ci-upstream/concretizer.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/concretizer.yaml

--- a/v1.1/ci-upstream/config.yaml
+++ b/v1.1/ci-upstream/config.yaml
@@ -1,0 +1,1 @@
+../../common/ci-upstream/config.yaml

--- a/v1.1/ci-upstream/modules.yaml
+++ b/v1.1/ci-upstream/modules.yaml
@@ -1,0 +1,1 @@
+../../common/ci-upstream/modules.yaml

--- a/v1.1/ci-upstream/packages.yaml
+++ b/v1.1/ci-upstream/packages.yaml
@@ -1,0 +1,1 @@
+../../common/ci/packages.yaml

--- a/v1.1/ci-upstream/repos.yaml
+++ b/v1.1/ci-upstream/repos.yaml
@@ -1,0 +1,1 @@
+../../common-api-v2/repos.yaml


### PR DESCRIPTION
This PR adds `ci-runner` and `ci-upstream` directories to the `v1.1` spack configs. These directories are equivalent to the `v1.0` configuration, except:

* common-api-v2/concretizer.yaml: set concretizer:compiler_mixing:false
* common/config.yaml: set deprecated:true to ensure Gadi's CMake version is accepted
* repos.yaml: use commit before the one that breaks the intel classic compiler
