### PR TITLE
Add an upstreams directory to the ukmo-restricted-scope

### DIFF
--- a/custom/cd/ukmo-restricted-scope/upstreams.yaml
+++ b/custom/cd/ukmo-restricted-scope/upstreams.yaml
@@ -1,0 +1,5 @@
+# This scope is used to manage UK Met Office restricted packages.
+# This file allows access to previously installed unrestricted packages.
+upstreams:
+  unrestricted:
+    install_tree: $spack/../release


### PR DESCRIPTION
Spack upstream mentioned that an environment loses access to packages already built and stored at the original install_tree directory when this scope changes the install_tree directory. To avoid this, we set the upstreams directory to the original install_tree directory.