### PR TITLE
common-api-v2/gadi/packages.yaml: remove superseded externals

### DIFF
--- a/common-api-v2/gadi/packages.yaml
+++ b/common-api-v2/gadi/packages.yaml
@@ -182,6 +182,15 @@ packages:
           c: /apps/gcc/14.2.0/wrappers/gcc
           cxx: /apps/gcc/14.2.0/wrappers/g++
           fortran: /apps/gcc/14.2.0/wrappers/gfortran
+    # https://github.com/ACCESS-NRI/system-tools
+    - spec: gcc@14.1.0 languages:='c,c++,fortran'
+      prefix: /apps/gcc/14.1.0/wrappers
+      modules: [gcc/14.1.0]
+      extra_attributes:
+        compilers:
+          c: /apps/gcc/14.1.0/wrappers/gcc
+          cxx: /apps/gcc/14.1.0/wrappers/g++
+          fortran: /apps/gcc/14.1.0/wrappers/gfortran
     - spec: gcc@13.2.0 languages:='c,c++,fortran'
       prefix: /apps/gcc/13.2.0/wrappers
       modules: [gcc/13.2.0]


### PR DESCRIPTION
* Spack v1.1 changed how externals need to be defined:
  * https://github.com/spack/spack/releases/tag/v1.1.0
  * https://spack.readthedocs.io/en/latest/packages_yaml.html#specifying-dependencies-among-external-packages
* This means that defining the least number of externals makes it easier to maintain this file.

* If we officially released a model that was built with a particular version of an external. It might be better not to remove it from our Spack configuration to allow a user to rebuild it.

* The next step, after this PR, is to specify a compiler version every time we specify a compiler in the spec of an external. e.g. `spec: openmpi@4.0.1 %gcc` changes to `spec: openmpi@4.0.1 %gcc@13.2.0`.