### PR TITLE
packages.yaml: add a preference for the x86_64 target

### DIFF
--- a/common-api-v2/gadi/packages.yaml
+++ b/common-api-v2/gadi/packages.yaml
@@ -271,3 +271,5 @@ packages:
         compilers:
           c: /usr/bin/clang
           cxx: /usr/bin/clang++
+  all:
+    target: [x86_64]

--- a/common/ci/packages.yaml
+++ b/common/ci/packages.yaml
@@ -17,3 +17,5 @@ packages:
     #version: [3.31.6, 3.24.4]
   libtool:
     version: [:2.4.6]
+  all:
+    target: [x86_64]

--- a/common/gadi/packages.yaml
+++ b/common/gadi/packages.yaml
@@ -371,3 +371,5 @@ packages:
           set:
             NCI_PYTHONX_AS_PYTHON: python3
     buildable: false
+  all:
+    target: [x86_64]


### PR DESCRIPTION
Due to Issue https://github.com/spack/spack/issues/51185 in Spack v1, setting a default preference for `x86_64` in our `spack-config` should mean our Spack v1 behaviour will more closely match our Spack v0.22 behaviour. Particularly when we create our CI Docker image using the `build-ci` `v3` branch instead of the `v1` branch.

### Testing
#### Before this change
```
[root@41445f817945 opt]# spack -V
1.1.1 (2e2169d5282d166f63e3ee4db8d4446c43cefa8a)

[root@41445f817945 opt]# spack find
-- linux-rocky8-x86_64 / no compilers ---------------------------
gcc@8.5.0  glibc@2.28  perl@5.26.3

-- linux-rocky8-x86_64_v4 / %c,cxx=gcc@8.5.0 --------------------
gcc@13.2.0      gmp@6.3.0  ncurses@6.5-20250705  zlib-ng@2.2.4
gettext@0.23.1  m4@1.4.20  texinfo@7.2           zstd@1.5.7

-- linux-rocky8-x86_64_v4 / %c=gcc@8.5.0 ------------------------
automake@1.16.5   gawk@5.3.1       libtool@2.4.6   pigz@2.8       xz@5.6.3
bzip2@1.0.8       gmake@4.4.1      libxml2@2.13.5  pkgconf@2.5.1
diffutils@3.12    libiconv@1.18    mpc@1.3.1       readline@8.3
findutils@4.10.0  libsigsegv@2.14  mpfr@4.2.1      tar@1.35

-- linux-rocky8-x86_64_v4 / no compilers ------------------------
autoconf@2.72                compiler-wrapper@1.0
autoconf-archive@2023.02.20  gcc-runtime@8.5.0
==> 32 installed packages
```

#### After this change
```
[root@b6686b7ced5a opt]# spack -V
1.1.1 (2e2169d5282d166f63e3ee4db8d4446c43cefa8a)

[root@b6686b7ced5a opt]# spack find
-- linux-rocky8-x86_64 / %c,cxx=gcc@8.5.0 -----------------------
gcc@13.2.0      gmp@6.3.0  ncurses@6.5-20250705  zlib-ng@2.2.4
gettext@0.23.1  m4@1.4.20  texinfo@7.2           zstd@1.5.7

-- linux-rocky8-x86_64 / %c=gcc@8.5.0 ---------------------------
automake@1.16.5   gawk@5.3.1       libtool@2.4.6   pigz@2.8       xz@5.6.3
bzip2@1.0.8       gmake@4.4.1      libxml2@2.13.5  pkgconf@2.5.1
diffutils@3.12    libiconv@1.18    mpc@1.3.1       readline@8.3
findutils@4.10.0  libsigsegv@2.14  mpfr@4.2.1      tar@1.35

-- linux-rocky8-x86_64 / no compilers ---------------------------
autoconf@2.72                gcc@8.5.0          perl@5.26.3
autoconf-archive@2023.02.20  gcc-runtime@8.5.0
compiler-wrapper@1.0         glibc@2.28
==> 32 installed packages
```

#### Before this change (build-ci v3 branch)
```
[root@7071420aa07a /]# spack -V
0.22.5 (422a81b3d75f3f119e7c06234418763803a4f070)

-- linux-rocky8-x86_64_v4 / gcc@8.5.0 ---------------------------
autoconf@2.72                gcc-runtime@8.5.0  libxml2@2.10.3  readline@8.2
autoconf-archive@2023.02.20  gettext@0.22.5     m4@1.4.19       tar@1.34
automake@1.16.5              glibc@2.28         mpc@1.3.1       texinfo@7.0.3
bzip2@1.0.8                  gmake@4.4.1        mpfr@4.2.1      xz@5.4.6
diffutils@3.10               gmp@6.2.1          ncurses@6.5     zlib-ng@2.1.6
findutils@4.9.0              libiconv@1.17      perl@5.26.3     zstd@1.5.6
gawk@5.3.0                   libsigsegv@2.14    pigz@2.8
gcc@13.2.0                   libtool@2.4.6      pkgconf@2.2.0
==> 30 installed packages
```

#### After this change (build-ci v3 branch)
```
[root@8fdd5c0e5f26 /]# spack -V
0.22.5 (422a81b3d75f3f119e7c06234418763803a4f070)

[root@8fdd5c0e5f26 /]# spack find
-- linux-rocky8-x86_64 / gcc@8.5.0 ------------------------------
autoconf@2.72                gcc-runtime@8.5.0  libxml2@2.10.3  readline@8.2
autoconf-archive@2023.02.20  gettext@0.22.5     m4@1.4.19       tar@1.34
automake@1.16.5              glibc@2.28         mpc@1.3.1       texinfo@7.0.3
bzip2@1.0.8                  gmake@4.4.1        mpfr@4.2.1      xz@5.4.6
diffutils@3.10               gmp@6.2.1          ncurses@6.5     zlib-ng@2.1.6
findutils@4.9.0              libiconv@1.17      perl@5.26.3     zstd@1.5.6
gawk@5.3.0                   libsigsegv@2.14    pigz@2.8
gcc@13.2.0                   libtool@2.4.6      pkgconf@2.2.0
==> 30 installed packages
```