### PR TITLE
common-api-v2/gadi/packages.yaml: externals are treated as concrete specs

### DIFF
--- a/common-api-v2/gadi/packages.yaml
+++ b/common-api-v2/gadi/packages.yaml
@@ -56,85 +56,42 @@ packages:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/5.0.8/include/GNU
     # ACCESS-ESM1.5 & ACCESS-OM2
-    - spec: openmpi@4.0.2 %intel@2021.10.0
+    - spec: openmpi@4.0.2
       prefix: /apps/openmpi/4.0.2
       modules: [openmpi/4.0.2]
       extra_attributes:
         environment:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/4.0.2/include/Intel
-    - spec: openmpi@4.0.7 %intel@2021.10.0
+    - spec: openmpi@4.0.7
       prefix: /apps/openmpi/4.0.7
       modules: [openmpi/4.0.7]
       extra_attributes:
         environment:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/4.0.7/include/Intel
-    - spec: openmpi@4.1.5 %intel@2021.10.0
+    - spec: openmpi@4.1.5
       prefix: /apps/openmpi/4.1.5
       modules: [openmpi/4.1.5]
       extra_attributes:
         environment:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/4.1.5/include/Intel
-    - spec: openmpi@4.1.7 %intel@2021.10.0
+    - spec: openmpi@4.1.7
       prefix: /apps/openmpi/4.1.7
       modules: [openmpi/4.1.7]
       extra_attributes:
         environment:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/4.1.7/include/Intel
-    - spec: openmpi@5.0.5 %intel@2021.10.0
+    - spec: openmpi@5.0.5
       prefix: /apps/openmpi/5.0.5
       modules: [openmpi/5.0.5]
       extra_attributes:
         environment:
           prepend_path:
             CMAKE_PREFIX_PATH: /apps/openmpi/5.0.5/include/Intel
-    - spec: openmpi@5.0.8 %intel@2021.10.0
-      prefix: /apps/openmpi/5.0.8
-      modules: [openmpi/5.0.8]
-      extra_attributes:
-        environment:
-          prepend_path:
-            CMAKE_PREFIX_PATH: /apps/openmpi/5.0.8/include/Intel
-    # ACCESS-ESM1.5 & ACCESS-OM2
-    - spec: openmpi@4.0.2 %oneapi@2025.2.0
-      prefix: /apps/openmpi/4.0.2
-      modules: [openmpi/4.0.2]
-      extra_attributes:
-        environment:
-          prepend_path:
-            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.2/include/Intel
-    - spec: openmpi@4.0.7 %oneapi@2025.2.0
-      prefix: /apps/openmpi/4.0.7
-      modules: [openmpi/4.0.7]
-      extra_attributes:
-        environment:
-          prepend_path:
-            CMAKE_PREFIX_PATH: /apps/openmpi/4.0.7/include/Intel
-    - spec: openmpi@4.1.5 %oneapi@2025.2.0
-      prefix: /apps/openmpi/4.1.5
-      modules: [openmpi/4.1.5]
-      extra_attributes:
-        environment:
-          prepend_path:
-            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.5/include/Intel
-    - spec: openmpi@4.1.7 %oneapi@2025.2.0
-      prefix: /apps/openmpi/4.1.7
-      modules: [openmpi/4.1.7]
-      extra_attributes:
-        environment:
-          prepend_path:
-            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.7/include/Intel
-    - spec: openmpi@5.0.5 %oneapi@2025.2.0
-      prefix: /apps/openmpi/5.0.5
-      modules: [openmpi/5.0.5]
-      extra_attributes:
-        environment:
-          prepend_path:
-            CMAKE_PREFIX_PATH: /apps/openmpi/5.0.5/include/Intel
-    - spec: openmpi@5.0.8 %oneapi@2025.2.0
+    - spec: openmpi@5.0.8
       prefix: /apps/openmpi/5.0.8
       modules: [openmpi/5.0.8]
       extra_attributes:


### PR DESCRIPTION
* As of https://github.com/spack/spack/pull/51118 we need to accommodate:
  "To be backward compatible with external specs specifying a compiler, for
   instance mpich %gcc@9, Spack will match the compiler specification to an
   existing external. It will fail when the specification is ambiguous, or
   if it does not match any other externals."