### PR TITLE
common-api-v2/gadi/packages.yaml: make python buildable

### DIFF
--- a/common-api-v2/gadi/packages.yaml
+++ b/common-api-v2/gadi/packages.yaml
@@ -120,7 +120,7 @@ packages:
         environment:
           set:
             NCI_PYTHONX_AS_PYTHON: python3
-    buildable: false
+    buildable: true
   gcc:
     externals:
     - spec: gcc@15.1.0 languages:='c,c++,fortran'
@@ -139,15 +139,6 @@ packages:
           c: /apps/gcc/14.2.0/wrappers/gcc
           cxx: /apps/gcc/14.2.0/wrappers/g++
           fortran: /apps/gcc/14.2.0/wrappers/gfortran
-    # https://github.com/ACCESS-NRI/system-tools
-    - spec: gcc@14.1.0 languages:='c,c++,fortran'
-      prefix: /apps/gcc/14.1.0/wrappers
-      modules: [gcc/14.1.0]
-      extra_attributes:
-        compilers:
-          c: /apps/gcc/14.1.0/wrappers/gcc
-          cxx: /apps/gcc/14.1.0/wrappers/g++
-          fortran: /apps/gcc/14.1.0/wrappers/gfortran
     - spec: gcc@13.2.0 languages:='c,c++,fortran'
       prefix: /apps/gcc/13.2.0/wrappers
       modules: [gcc/13.2.0]


### PR DESCRIPTION
* The Python versions available on Spack v1.1 are not available on Gadi. e.g. 3.11.7. By making python buildable we get more flexibility.
* system-tools now uses gcc@15.1.0. We can remove gcc@14.1.0.