### PR TITLE
common-api-v2/repos.yaml: set access-spack-packages location

### DIFF
--- a/common-api-v2/repos.yaml
+++ b/common-api-v2/repos.yaml
@@ -3,6 +3,7 @@ repos::
   access_spack_packages:
     git: https://github.com/ACCESS-NRI/access-spack-packages.git
     branch: api-v2
+    destination: $spack/../access-spack-packages
   builtin:
     git: https://github.com/spack/spack-packages.git
     # gnu packages: bump (#3390)


### PR DESCRIPTION
* The directory location of `access-spack-packages` will be explicitly set to avoid the default location set by Spack.

* Following the discussion with @penguian on Tuesday, while updating the `access-spack-packages` README to Spack v1.1 (PR https://github.com/ACCESS-NRI/access-spack-packages/pull/389), it occurred to me that the *user experience* of having `access-spack-packages` embedded in the Spack defined directory structure makes it less visible and accessible to a user that wants to modify an SPR in `access-spack-packages`. 

### Testing
```
[root@1ed7c1928f7e opt]# rm -rf package_repos/3t2klr5

[root@1ed7c1928f7e opt]# spack repo list
 -  access_spack_packages            https://github.com/ACCESS-NRI/access-spack-packages.git
[+] builtin                  v2.2    /opt/package_repos/fncqgg4/repos/spack_repo/builtin

[root@1ed7c1928f7e opt]# spack repo update
remote: Enumerating objects: 157, done.
remote: Counting objects: 100% (157/157), done.
remote: Compressing objects: 100% (91/91), done.
remote: Total 157 (delta 31), reused 118 (delta 15), pack-reused 0 (from 0)
==> access_spack_packages: Updated sucessfully.
==> builtin: Already up to date.

[root@1ed7c1928f7e opt]# spack repo list
[+] access.nri    v2.0    /opt/access-spack-packages/spack_repo/access/nri
[+] builtin       v2.2    /opt/package_repos/fncqgg4/repos/spack_repo/builtin

[root@1ed7c1928f7e opt]# spack list oasis3-mct
oasis3-mct
==> 1 packages
```