### PR TITLE
common-api-v2/repos.yaml: allow users to add additional repos

### DIFF
--- a/common-api-v2/repos.yaml
+++ b/common-api-v2/repos.yaml
@@ -1,10 +1,10 @@
 # Completely ignoring lower-precedence configuration options is supported with the :: notation for keys
-repos::
-  access_spack_packages:
+repos:
+  access_spack_packages::
     git: https://github.com/ACCESS-NRI/access-spack-packages.git
     branch: api-v2
     destination: $spack/../access-spack-packages
-  builtin:
+  builtin::
     git: https://github.com/spack/spack-packages.git
     # gnu packages: bump (#3390)
     commit: 383e969358c951abe17623696083e6f862c4488e


### PR DESCRIPTION
* Prior to this change, adding a repo via user scope would not have been recognised.
* This change may assist in moving to a shared Spack instance.