### PR TITLE
Add modules for ukmo-restricted scope under the custom release directory

### DIFF
--- a/custom/cd/ukmo-restricted-scope/modules.yaml
+++ b/custom/cd/ukmo-restricted-scope/modules.yaml
@@ -1,0 +1,6 @@
+modules:
+  default:
+    roots:
+      # For binaries under the restricted/ukmo/release directory, we also want to
+      # generate modulefiles under restricted/ukmo/release/modules.
+      tcl: $spack/../restricted/ukmo/release/modules


### PR DESCRIPTION
Relates to https://github.com/ACCESS-NRI/build-cd/pull/370
Closes ACCESS-NRI/build-cd#369

## Background

Before the above PR, we generated modulefiles under the same ukmo restricted scope as the `spack install` command. This generated the modules successfully (in the regular `$spack/../release/modules` directory), but the dependency modules were not accessible. 

When we then regenerated the modules under the regular scope, it worked - we could load the dependency modules as well. 

As an interim fix, we just regenerated the modules in the regular scope, but this led to no modules being found (including the base `access-am3` one), because the `spack module tcl refresh` command didn't know where the binaries were without the `ukmo-restricted` scope being applied!

Therefore, the solution is to enable restricted modules to be generated via a custom `$spack/../restricted/ukmo/release/modules` module dir, reverting the fix in `build-cd`, and updating the module magic to look in the above restricted module location. 

## The PR

* Add a custom module root for our `ukmo-restricted-scope`

## Testing

Tested modules manually by adding the file to the config scope manually in the prerelease instance, then doing `spack -e access-am3-pr34-3 -C $spack/../spack-config/custom/cd/ukmo-restricted-scope module tcl refresh -y`, then `module use $spack/../restricted/ukmo/release/modules && module load access-am3/pr34-3`, which gave the expected:

```
Loading access-am3/pr34-3
  Loading requirement: access-am3/dependencies/pr34-3/openmpi/4.1.7-d2wgjcx
    access-am3/dependencies/pr34-3/um/13.1-lbyc5hl
```
