### PR TITLE
gadi/modules.yaml: do not create openmpi modulefile

### DIFF
--- a/v1.1/gadi/modules.yaml
+++ b/v1.1/gadi/modules.yaml
@@ -1,0 +1,6 @@
+# Refer to https://spack.readthedocs.io/en/latest/module_file_support.html
+modules:
+  default:
+    tcl:
+      # https://spack.readthedocs.io/en/latest/module_file_support.html#exclude-or-include-specific-module-files
+      exclude: ["openmpi"]


### PR DESCRIPTION
If we do not want Spack to create a modulefile for the system openmpi. We should try this.