### PR TITLE
v1.1/repos.yaml: update spack-packages to newer commit

### DIFF
--- a/v1.1/repos.yaml
+++ b/v1.1/repos.yaml
@@ -6,6 +6,5 @@ repos:
     destination: $spack/../access-spack-packages
   builtin::
     git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
-    # gcc: use link type dep for binutils (#3671)
-    commit: 2f02a99ec9dfd5dceb9bd91abc392edabd9ba963
+    branch: access/v1.1
     destination: $spack/../spack-packages

--- a/v1.1/repos.yaml
+++ b/v1.1/repos.yaml
@@ -6,6 +6,5 @@ repos:
     destination: $spack/../access-spack-packages
   builtin::
     git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
-    # gcc: use link type dep for binutils (#3671)
-    commit: 2f02a99ec9dfd5dceb9bd91abc392edabd9ba963
+    branch: access/v1.1-test
     destination: $spack/../spack-packages


### PR DESCRIPTION
* The ISM team needs commit 7d252c0ddf0fca65f67775e38db4606bd47c8cc4 (mumps: fix compilation with oneAPI)
* ACCESS-NRI decided to create a fork of `spack/spack-packages`: https://github.com/ACCESS-NRI/upstream-spack-packages/
* The branch we will use is `access/v1.1`
* QA done in https://github.com/ACCESS-NRI/upstream-spack-packages/pull/2