### PR TITLE
v1.1/gadi/packages.yaml: add oneapi@2025.3.2

### DIFF
--- a/v1.1/gadi/packages.yaml
+++ b/v1.1/gadi/packages.yaml
@@ -146,7 +146,16 @@ packages:
     # 2025.0.4 -> /apps/intel-tools/.packages/2025.0.1/compiler/2025.0
     # 2025.1.1 -> /apps/intel-tools/.packages/2025.1.3/compiler/2025.1
     # 2025.2.0 -> /apps/intel-tools/.packages/2025.2.0.575/compiler/2025.2
+    # 2025.3.2 -> /apps/intel-tools/.packages/2025.3.1.55/compiler/2025.3
     externals:
+    - spec: intel-oneapi-compilers@2025.3.2
+      prefix: /apps/intel-tools/.packages/2025.3.1.55
+      modules: [intel-compiler-llvm/2025.3.2]
+      extra_attributes:
+        compilers:
+          c: /apps/intel-tools/wrappers/icx
+          cxx: /apps/intel-tools/wrappers/icpx
+          fortran: /apps/intel-tools/wrappers/ifx
     - spec: intel-oneapi-compilers@2025.2.0
       prefix: /apps/intel-tools/.packages/2025.2.0.575
       modules: [intel-compiler-llvm/2025.2.0]


### PR DESCRIPTION
### Testing
```
$ spack compiler list
==> Available compilers
-- gcc rocky8-x86_64 --------------------------------------------
[e]  gcc@8.5.0  [e]  gcc@15.1.0  [e]  gcc@14.2.0  [e]  gcc@13.2.0

-- intel-oneapi-compilers rocky8-x86_64 -------------------------
[e]  intel-oneapi-compilers@2025.3.2  [e]  intel-oneapi-compilers@2025.1.1
[e]  intel-oneapi-compilers@2025.2.0

-- intel-oneapi-compilers-classic rocky8-x86_64 -----------------
[e]  intel-oneapi-compilers-classic@2021.13.1
[e]  intel-oneapi-compilers-classic@2021.10.0
[e]  intel-oneapi-compilers-classic@19.0.5.281
[e]  intel-oneapi-compilers-classic@19.0.3.199

-- llvm rocky8-x86_64 -------------------------------------------
[e]  llvm@19.1.7
```
```
$ spack install tree %oneapi@2025.3.2
...
$ spack find %oneapi@2025.3.2
-- linux-rocky8-x86_64 / %c=oneapi@2025.3.2 ---------------------
tree@2.1.0

-- linux-rocky8-x86_64 / no compilers ---------------------------
intel-oneapi-runtime@2025.3.2
==> 2 installed packages
```