### PR TITLE
v1.1/gadi/downstream/upstreams.yaml: remove prerelease

### DIFF
--- a/v1.1/gadi/downstream/upstreams.yaml
+++ b/v1.1/gadi/downstream/upstreams.yaml
@@ -1,5 +1,3 @@
 upstreams:
   release:
     install_tree: /g/data/vk83/apps/spack/1.1/release
-  prerelease:
-    install_tree: /g/data/vk83/prerelease/apps/spack/1.1/release


### PR DESCRIPTION
* The state of prerelease is unpredicatable.