### PR TITLE
v1.1/gadi/packages.yaml: add external cmake

### DIFF
--- a/v1.1/gadi/packages.yaml
+++ b/v1.1/gadi/packages.yaml
@@ -1,4 +1,16 @@
 packages:
+  cmake:
+    externals:
+    - spec: cmake@4.3.3
+      prefix: /apps/cmake/4.3.3
+      modules: [cmake/4.3.3]
+    - spec: cmake@3.31.12
+      prefix: /apps/cmake/3.31.12
+      modules: [cmake/3.31.12]
+    - spec: cmake@3.24.2
+      prefix: /apps/cmake/3.24.2
+      modules: [cmake/3.24.2]
+    buildable: false
   openmpi:
     # https://spack.readthedocs.io/en/latest/configuration.html#environment-modifications
     externals:


### PR DESCRIPTION
* We requested cmake 3.31.12 and 4.3.3 to be installed on Gadi. They have been installed.
* We previously had cmake 3.24.2 as an external.
* We previously disabled building of cmake.
* The ACCESS-NRI fork of `spack-packages` will need a modified cmake SPR that includes these three versions of cmake.