### PR TITLE
v1.1/gadi/packages.yaml: add the newest system python versions available

### DIFF
--- a/v1.1/gadi/packages.yaml
+++ b/v1.1/gadi/packages.yaml
@@ -110,9 +110,6 @@ packages:
     buildable: false
   python:
     externals:
-    - spec: python@3.11.7
-      prefix: /apps/python3/3.11.7
-      modules: [python3/3.11.7]
       # $ module show python3-as-python
       # -------------------------------------------------------------------
       # /apps/Modules/modulefiles/python3-as-python:
@@ -120,6 +117,16 @@ packages:
       # conflict        python2-as-python
       # setenv          NCI_PYTHONX_AS_PYTHON python3
       # -------------------------------------------------------------------
+    - spec: python@3.12.13
+      prefix: /apps/python3/3.12.13
+      modules: [python3/3.12.13]
+      extra_attributes:
+        environment:
+          set:
+            NCI_PYTHONX_AS_PYTHON: python3
+    - spec: python@3.11.7
+      prefix: /apps/python3/3.11.7
+      modules: [python3/3.11.7]
       extra_attributes:
         environment:
           set:


### PR DESCRIPTION
Closes: #80 

NCI installed Python 3.12.13 on Gadi's /apps .