### PR TITLE
Use wrappers in nvidia-hpc-sdk compiler

### DIFF
--- a/v1.1/gadi/packages.yaml
+++ b/v1.1/gadi/packages.yaml
@@ -231,9 +231,9 @@ packages:
       modules: [nvidia-hpc-sdk/25.9, cuda/12.9.0] # cuda needed to compile GPU code
       extra_attributes:
         compilers:
-          c: /apps/nvidia-hpc-sdk/25.9/compilers/bin/nvc
-          cxx: /apps/nvidia-hpc-sdk/25.9/compilers/bin/nvc++
-          fortran: /apps/nvidia-hpc-sdk/25.9/compilers/bin/nvfortran
+          c: /apps/nvidia-hpc-sdk/wrappers/nvc
+          cxx: /apps/nvidia-hpc-sdk/wrappers/nvc++
+          fortran: /apps/nvidia-hpc-sdk/wrappers/nvfortran
   llvm:
     externals:
     - spec: llvm@19.1.7+clang~flang~lld~lldb


### PR DESCRIPTION
This updates the package config to use the NCI compiler wrapper for nvidia hpc sdk compilers. This brings the spec in line with how they're done for intel and gcc compilers in the config.

This resolves issues i was experiencing with fms cmake not finding the fortran openmpi libs when compiling with nvhpc.